### PR TITLE
Remove dead code from the demo app

### DIFF
--- a/app/schemas.py
+++ b/app/schemas.py
@@ -32,11 +32,6 @@ class CreatorOut(BaseModel):
     last_name: str
     email: str
 
-    @property
-    def label(self) -> str:
-        """Matches the Streamlit rendering: "First Last (email)"."""
-        return f"{self.first_name} {self.last_name} ({self.email})"
-
 
 class DatasetSummary(BaseModel):
     id: int
@@ -208,19 +203,6 @@ class PublishDraft(BaseModel):
     @property
     def can_publish(self) -> bool:
         return self.has_metadata and not self.validation_errors
-
-    @property
-    def current_step(self) -> int:
-        """Furthest step the draft has reached, used to resume and to draw the stepper."""
-        if self.published_dataset_id:
-            return 4
-        if self.has_metadata:
-            return 4
-        if self.data_uploaded:
-            return 3
-        if self.metadata_complete:
-            return 2
-        return 1
 
     @property
     def metadata_filename(self) -> str:

--- a/app/static/src/app.css
+++ b/app/static/src/app.css
@@ -233,8 +233,6 @@
 :root {
   --uw-link: #036796;
   --uw-link-hover: #023d54;
-  --uw-footer-bg: #282728;
-  --uw-footer-fg: #adadad;
   --uw-footer-hover: #f3f3f3;
 }
 

--- a/app/templating.py
+++ b/app/templating.py
@@ -27,16 +27,8 @@ def pretty_json(value: Any) -> str:
     return json.dumps(value, indent=2, default=str)
 
 
-def keyword_list(value: str | None) -> list[str]:
-    """Split the comma-separated `Dataset.keywords` column into trimmed values."""
-    if not value:
-        return []
-    return [part.strip() for part in value.split(",") if part.strip()]
-
-
 templates.env.filters["short_sha"] = short_sha
 templates.env.filters["pretty_json"] = pretty_json
-templates.env.filters["keyword_list"] = keyword_list
 templates.env.globals["settings"] = settings
 
 


### PR DESCRIPTION
Removes 28 lines of genuinely unreferenced code, found by auditing every symbol in the app against the templates, routers, and notebooks.

### Removed

- **`keyword_list` Jinja filter** (`app/templating.py`) — the DTOs already hand templates a real list (`DatasetSummary.keywords`), so no template ever split the comma-separated column.
- **`CreatorOut.label`** (`app/schemas.py`) — a leftover of the Streamlit rendering; `_card.html` and `detail.html` both compose the name and email themselves.
- **`PublishDraft.current_step`** (`app/schemas.py`) — its docstring claimed the stepper used it, but `_stepper.html` gates on the individual flags (`metadata_complete`, `data_uploaded`, `has_metadata`, `published_dataset_id`).
- **`--uw-footer-bg` / `--uw-footer-fg`** (`app/static/src/app.css`) — consumed by nothing. `_uw_footer.html` deliberately writes those two greys as literals, since the UW footer is charcoal regardless of the surrounding palette.

### daisyUI is still load-bearing — not touched

`app.css` declares `@plugin "daisyui"` plus the whole custom `uwmadison` theme via `@plugin "daisyui/theme"`, and the templates use 60+ distinct daisyUI component classes (`btn` ×27, plus card / alert / badge / steps / collapse / join / stat / table / loading / indicator / divider). `app/smoke_test.py` already asserts `.btn`, `.card`, and `.steps` appear in the built stylesheet.

### Audited and deliberately kept

These are unused *by the app* but are not leftovers:

- `DataRepoEngine`, `initialize_database`, `get_session`, `Dataset.pull()`, `guess_primary_url` — exercised by `notebooks/fsspec.ipynb`, `notebooks/jsonld_to_db.ipynb`, and `notebooks/metadata_creation/Image_parquet_metadata.ipynb`. (`services/datasets.py` documents why the app avoids `DataRepoEngine`.)
- `pelican_data_loader/external/person_api.py` (303 lines) — nothing in the app imports it; only `notebooks/integration_person_api.ipynb` pulls `get_oauth_token`, and that notebook records the API as broken through the Workday transition. Parked WIP. It is also the sole consumer of the `wisc_oauth_url` / `wisc_client_id` / `wisc_client_secret` config fields.
- `pelican_data_loader/data/licenses.jsonl` + `scripts/pull_licenses.py` — the app hardcodes six licenses in `services/licenses.py`; nothing reads the SPDX file. An unwired asset the README documents.
- `/readyz` — no caller (the compose healthcheck uses `/healthz`), but intentional ops surface.
- `PublishDraft.created_at` — never read; kept as a persisted record in `draft.json`.
- The `.btn-link` box-shadow reset — `btn-link` appears in no template, kept as a defensive design-system rule.

All 29 templates are referenced, every route is reachable from markup or config, and ruff reports no unused imports.

### Verification

`ruff check` clean. `app/smoke_test.py` compiles all 29 templates and renders every route at 200, including the out-of-band stepper contract on `POST /publish/step1`. Its only failure is the missing built `app/static/css/app.css` — `bun` isn't installed on the machine this ran on and assets are built inside Docker, so that failure is environmental and pre-existing.

Because `app/static/src/app.css` changed, a redeploy needs the usual `bun run build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
